### PR TITLE
Fix CoreMIDI framework not found

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,8 +301,7 @@ impl ::std::default::Default for Struct_MIDIThruConnectionParams {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 pub type MIDIThruConnectionParams = Struct_MIDIThruConnectionParams;
-#[link(name = "/System/Library/Frameworks/CoreMIDI.framework",
-       kind = "framework")]
+#[link(name = "CoreMIDI", kind = "framework")]
 extern "C" {
     pub static kMIDIPropertyName: CFStringRef;
     pub static kMIDIPropertyManufacturer: CFStringRef;
@@ -351,8 +350,7 @@ extern "C" {
     pub static kMIDIPropertySupportsShowControl: CFStringRef;
     pub static kMIDIPropertyDisplayName: CFStringRef;
 }
-#[link(name = "/System/Library/Frameworks/CoreMIDI.framework",
-       kind = "framework")]
+#[link(name = "CoreMIDI", kind = "framework")]
 extern "C" {
     pub fn MIDIClientCreate(name: CFStringRef, notifyProc: MIDINotifyProc,
                             notifyRefCon: *mut ::libc::c_void,


### PR DESCRIPTION
```
error: linking with `cc` failed: exit code: 1
  |
  = note: "cc" "-m64" "-L" "/usr/local/Cellar/rust/1.13.0/lib/rustlib/x86_64-apple-darwin/lib" "/.../target/debug/midict1.0.o" "-o" "/.../target/debug/midict1" "-Wl,-dead_strip" "-nodefaultlibs" "-L" "/.../target/debug/deps" "-L" "/usr/local/Cellar/rust/1.13.0/lib/rustlib/x86_64-apple-darwin/lib" "/.../target/debug/deps/libcore_foundation-245dd61b84af40c8.rlib" "/.../target/debug/deps/libcoremidi_sys.rlib" "/.../target/debug/deps/libcore_foundation_sys-81dca212fe529d13.rlib" "/.../target/debug/deps/libtime-750bfdd52feafcb7.rlib" "/.../target/debug/deps/liblibc-6ec63c5a0e74a074.rlib" "/usr/local/Cellar/rust/1.13.0/lib/rustlib/x86_64-apple-darwin/lib/libstd-a4729905.rlib" "/usr/local/Cellar/rust/1.13.0/lib/rustlib/x86_64-apple-darwin/lib/libpanic_unwind-a4729905.rlib" "/usr/local/Cellar/rust/1.13.0/lib/rustlib/x86_64-apple-darwin/lib/libunwind-a4729905.rlib" "/usr/local/Cellar/rust/1.13.0/lib/rustlib/x86_64-apple-darwin/lib/librand-a4729905.rlib" "/usr/local/Cellar/rust/1.13.0/lib/rustlib/x86_64-apple-darwin/lib/libcollections-a4729905.rlib" "/usr/local/Cellar/rust/1.13.0/lib/rustlib/x86_64-apple-darwin/lib/librustc_unicode-a4729905.rlib" "/usr/local/Cellar/rust/1.13.0/lib/rustlib/x86_64-apple-darwin/lib/liballoc-a4729905.rlib" "/usr/local/Cellar/rust/1.13.0/lib/rustlib/x86_64-apple-darwin/lib/liballoc_jemalloc-a4729905.rlib" "/usr/local/Cellar/rust/1.13.0/lib/rustlib/x86_64-apple-darwin/lib/liblibc-a4729905.rlib" "/usr/local/Cellar/rust/1.13.0/lib/rustlib/x86_64-apple-darwin/lib/libcore-a4729905.rlib" "/usr/local/Cellar/rust/1.13.0/lib/rustlib/x86_64-apple-darwin/lib/libcompiler_builtins-a4729905.rlib" "-framework" "/System/Library/Frameworks/CoreMIDI.framework" "-framework" "/System/Library/Frameworks/CoreMIDI.framework" "-framework" "CoreFoundation" "-l" "System" "-l" "pthread" "-l" "c" "-l" "m"
  = note: ld: framework not found /System/Library/Frameworks/CoreMIDI.framework
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```