### PR TITLE
Fixed structs to packed. Added example to send notes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,6 @@ homepage = "https://github.com/jonas-k/coremidi-sys"
 
 [dependencies]
 core-foundation-sys = "0.2"
+core-foundation = "0.2"
 libc = "0.2"
+time = "0.1"

--- a/examples/send-notes.rs
+++ b/examples/send-notes.rs
@@ -3,16 +3,16 @@ extern crate coremidi_sys;
 extern crate time;
 extern crate libc;
 
-use core_foundation::string::{CFString, CFStringRef, CFStringGetLength, UniChar};
-use core_foundation::base::{TCFType, CFIndex, CFRelease};
+use core_foundation::string::{CFString, CFStringRef};
+use core_foundation::base::{TCFType};
 
 use coremidi_sys::{
     MIDIGetNumberOfDestinations, MIDIGetDestination,
     MIDIObjectGetStringProperty, kMIDIPropertyDisplayName,
     MIDIPacketList, MIDIPacket,
     MIDIClientRef, MIDIClientCreate, MIDIClientDispose,
-    MIDIPortRef, MIDIOutputPortCreate,
-    MIDIEndpointRef, MIDISend, ItemCount };
+    MIDIPortRef, MIDIOutputPortCreate, MIDIPortDispose,
+    MIDIEndpointRef, MIDISend, ItemCount, UInt16};
 
 use std::time::Duration;
 use std::thread;
@@ -22,30 +22,28 @@ use std::env;
 
 fn main() {
     let destination_index = get_destination_index();
-
     println!("Destination index: {}", destination_index);
 
-    let client = create_client("example-client");
+    let client = create_client("example-client")
+        .expect("Failed to create a client");
 
-    let output_port = create_output_port(client, "example-port");
+    let output_port = create_output_port(client, "example-port")
+        .expect("Failed to create an output port");
 
-    let endpoint: MIDIEndpointRef = unsafe { MIDIGetDestination(destination_index) };
+    let endpoint = get_destination(destination_index);
 
-    for _ in 0..10 {
-        println!("Sending note ...");
+    for i in 0..10 {
+        println!("[{}] Sending note ...", i);
 
-        let packet_list = create_note_on(0, 64, 127);
-        let status = unsafe { MIDISend(output_port, endpoint, &packet_list) };
-        assert!(status == 0, "Failed to send a packet list");
+        send(output_port, endpoint, create_note_on(0, 64, 127));
 
         thread::sleep(Duration::from_millis(1000));
 
-        let packet_list = create_note_off(0, 64, 127);
-        let status = unsafe { MIDISend(output_port, endpoint, &packet_list) };
-        assert!(status == 0, "Failed to send a packet list");
+        send(output_port, endpoint, create_note_off(0, 64, 127));
     }
 
-    unsafe { MIDIClientDispose(client) };
+    dispose_port(output_port);
+    dispose_client(client);
 }
 
 fn get_destination_index() -> ItemCount {
@@ -89,7 +87,22 @@ fn print_destinations() {
     }
 }
 
-fn create_client(name: &str) -> MIDIClientRef {
+fn get_display_name(endpoint: MIDIEndpointRef) -> Option<String> {
+    let mut display_name_ref: CFStringRef = unsafe { mem::uninitialized() };
+    let status = unsafe { MIDIObjectGetStringProperty(
+        endpoint,
+        kMIDIPropertyDisplayName,
+        &mut display_name_ref) };
+    if status == 0 {
+        let display_name: CFString = unsafe { TCFType::wrap_under_create_rule(display_name_ref) };
+        Some(format!("{}", display_name))
+    }
+    else {
+        None
+    }
+}
+
+fn create_client(name: &str) -> Option<MIDIClientRef> {
     let client_name = CFString::new(name);
     let mut client: MIDIClientRef = unsafe { mem::uninitialized() };
     let status = unsafe { MIDIClientCreate(
@@ -97,12 +110,10 @@ fn create_client(name: &str) -> MIDIClientRef {
         None, ptr::null_mut(),
         &mut client)
     };
-    assert!(status == 0, "Failed to create a client");
-
-    client
+    if status == 0 { Some(client) } else { None }
 }
 
-fn create_output_port(client: MIDIClientRef, name: &str) -> MIDIPortRef {
+fn create_output_port(client: MIDIClientRef, name: &str) -> Option<MIDIPortRef> {
     let output_port_name = CFString::new(name);
     let mut output_port: MIDIPortRef = unsafe { mem::uninitialized() };
     let status = unsafe { MIDIOutputPortCreate(
@@ -110,48 +121,44 @@ fn create_output_port(client: MIDIClientRef, name: &str) -> MIDIPortRef {
         output_port_name.as_concrete_TypeRef(),
         &mut output_port)
     };
-    assert!(status == 0, "Failed to create an output port for {}", output_port_name);
-
-    output_port
+    if status == 0 { Some(output_port) } else { None }
 }
 
-fn create_note_on(channel: u8, note: u8, velocity: u8) -> MIDIPacketList {
-    let mut packet = MIDIPacket { timeStamp: 0, length: 3, data: [0; 256] };
-    packet.data[0] = 0x90 | (channel & 0x0f);
-    packet.data[1] = note & 0x7f;
-    packet.data[2] = velocity & 0x7f;
+fn get_destination(index: ItemCount) -> MIDIEndpointRef {
+    unsafe { MIDIGetDestination(index) }
+}
 
+fn create_note_on(channel: u8, note: u8, velocity: u8) -> Vec<u8> {
+    vec![
+        0x90 | (channel & 0x0f),
+        note & 0x7f,
+        velocity & 0x7f]
+}
+
+fn create_note_off(channel: u8, note: u8, velocity: u8) -> Vec<u8> {
+    vec![
+        0x80 | (channel & 0x0f),
+        note & 0x7f,
+        velocity & 0x7f]
+}
+
+fn create_packet_list(data: Vec<u8>) -> MIDIPacketList {
+    let len = data.len();
+    let mut packet = MIDIPacket { timeStamp: 0, length: len as UInt16, data: [0; 256] };
+    packet.data[0..len].clone_from_slice(&data);
     MIDIPacketList { numPackets: 1, packet: [packet]}
 }
 
-fn create_note_off(channel: u8, note: u8, velocity: u8) -> MIDIPacketList {
-    let mut packet = MIDIPacket { timeStamp: 0, length: 3, data: [0; 256] };
-    packet.data[0] = 0x80 | (channel & 0x0f);
-    packet.data[1] = note & 0x7f;
-    packet.data[2] = velocity & 0x7f;
-
-    MIDIPacketList { numPackets: 1, packet: [packet] }
+fn send(port: MIDIPortRef, endpoint: MIDIEndpointRef, data: Vec<u8>) {
+    let packet_list = create_packet_list(data);
+    let status = unsafe { MIDISend(port, endpoint, &packet_list) };
+    assert!(status == 0, "Failed to send data");
 }
 
-extern {
-    pub fn CFStringGetCharacterAtIndex(theString: CFStringRef, index: CFIndex) -> UniChar;
+fn dispose_port(port: MIDIPortRef) {
+    unsafe { MIDIPortDispose(port) };
 }
 
-fn get_display_name(endpoint: MIDIEndpointRef) -> Option<String> {
-    unsafe {
-        let mut display_name_ref: CFStringRef = mem::uninitialized();
-        match MIDIObjectGetStringProperty(endpoint, kMIDIPropertyDisplayName, &mut display_name_ref) {
-            0 => {
-                let mut name_chars = Vec::<char>::new();
-                let len = CFStringGetLength(display_name_ref);
-                for i in 0..len {
-                    let ch = CFStringGetCharacterAtIndex(display_name_ref, i);
-                    name_chars.push(std::char::from_u32(ch as u32).unwrap());
-                }
-                CFRelease(display_name_ref as *mut libc::c_void);
-                Some(name_chars.iter().cloned().collect::<String>())
-            },
-            _ => None
-        }
-    }
+fn dispose_client(client: MIDIClientRef) {
+    unsafe { MIDIClientDispose(client) };
 }

--- a/examples/send-notes.rs
+++ b/examples/send-notes.rs
@@ -1,0 +1,156 @@
+extern crate core_foundation;
+extern crate coremidi_sys;
+extern crate time;
+extern crate libc;
+
+use core_foundation::string::{CFString, CFStringRef, CFStringGetLength, UniChar};
+use core_foundation::base::{TCFType, CFIndex};
+
+use coremidi_sys::{
+    MIDIGetNumberOfDestinations, MIDIGetDestination,
+    MIDIObjectGetStringProperty, kMIDIPropertyDisplayName,
+    MIDIPacketList, MIDIPacket,
+    MIDIClientRef, MIDIClientCreate, MIDIClientDispose,
+    MIDIPortRef, MIDIOutputPortCreate,
+    MIDIEndpointRef, MIDISend, ItemCount };
+
+use std::time::Duration;
+use std::thread;
+use std::ptr;
+use std::mem;
+use std::env;
+
+fn main() {
+    let destination_index = get_destination_index();
+
+    println!("Destination index: {}", destination_index);
+
+    let client = create_client("example-client");
+
+    let output_port = create_output_port(client, "example-port");
+
+    let endpoint: MIDIEndpointRef = unsafe { MIDIGetDestination(destination_index) };
+
+    for _ in 0..10 {
+        println!("Sending note ...");
+
+        let packet_list = create_note_on(0, 64, 127);
+        let status = unsafe { MIDISend(output_port, endpoint, &packet_list) };
+        assert!(status == 0, "Failed to send a packet list");
+
+        thread::sleep(Duration::from_millis(1000));
+
+        let packet_list = create_note_off(0, 64, 127);
+        let status = unsafe { MIDISend(output_port, endpoint, &packet_list) };
+        assert!(status == 0, "Failed to send a packet list");
+    }
+
+    unsafe { MIDIClientDispose(client) };
+}
+
+fn get_destination_index() -> ItemCount {
+    let mut args_iter = env::args();
+    args_iter.next();
+    match args_iter.next() {
+        Some(arg) => match arg.parse::<ItemCount>() {
+            Ok(index) => {
+                let num_devices = unsafe { MIDIGetNumberOfDestinations() };
+                if index >= num_devices {
+                    println!("Destination index out of range: {}", index);
+                    std::process::exit(-1);
+                }
+                index
+            },
+            Err(_) => {
+                println!("Wrong destination index: {}", arg);
+                std::process::exit(-1);
+            }
+        },
+        None => {
+            println!("Usage: send <destination-index>");
+            println!("");
+            println!("Available Outputs:");
+            print_destinations();
+            std::process::exit(-1);
+        }
+    }
+}
+
+fn print_destinations() {
+    unsafe {
+        let num_devices = MIDIGetNumberOfDestinations();
+        for i in 0..num_devices {
+            let endpoint: MIDIEndpointRef = MIDIGetDestination(i);
+            match get_display_name(endpoint) {
+                Some(display_name) => println!("[{}] {}", i, display_name),
+                None => {}
+            }
+        }
+    }
+}
+
+fn create_client(name: &str) -> MIDIClientRef {
+    let client_name = CFString::new(name);
+    let mut client: MIDIClientRef = unsafe { mem::uninitialized() };
+    let status = unsafe { MIDIClientCreate(
+        client_name.as_concrete_TypeRef(),
+        None, ptr::null_mut(),
+        &mut client)
+    };
+    assert!(status == 0, "Failed to create a client");
+
+    client
+}
+
+fn create_output_port(client: MIDIClientRef, name: &str) -> MIDIPortRef {
+    let output_port_name = CFString::new(name);
+    let mut output_port: MIDIPortRef = unsafe { mem::uninitialized() };
+    let status = unsafe { MIDIOutputPortCreate(
+        client,
+        output_port_name.as_concrete_TypeRef(),
+        &mut output_port)
+    };
+    assert!(status == 0, "Failed to create an output port for {}", output_port_name);
+
+    output_port
+}
+
+fn create_note_on(channel: u8, note: u8, velocity: u8) -> MIDIPacketList {
+    let mut packet = MIDIPacket { timeStamp: 0, length: 3, data: [0; 256] };
+    packet.data[0] = 0x90 | (channel & 0x0f);
+    packet.data[1] = note & 0x7f;
+    packet.data[2] = velocity & 0x7f;
+
+    MIDIPacketList { numPackets: 1, packet: [packet]}
+}
+
+fn create_note_off(channel: u8, note: u8, velocity: u8) -> MIDIPacketList {
+    let mut packet = MIDIPacket { timeStamp: 0, length: 3, data: [0; 256] };
+    packet.data[0] = 0x80 | (channel & 0x0f);
+    packet.data[1] = note & 0x7f;
+    packet.data[2] = velocity & 0x7f;
+
+    MIDIPacketList { numPackets: 1, packet: [packet] }
+}
+
+extern {
+    pub fn CFStringGetCharacterAtIndex(theString: CFStringRef, index: CFIndex) -> UniChar;
+}
+
+fn get_display_name(endpoint: MIDIEndpointRef) -> Option<String> {
+    unsafe {
+        let mut display_name_ref: CFStringRef = mem::uninitialized();
+        match MIDIObjectGetStringProperty(endpoint, kMIDIPropertyDisplayName, &mut display_name_ref) {
+            0 => {
+                let mut name_chars = Vec::<char>::new();
+                let len = CFStringGetLength(display_name_ref);
+                for i in 0..len {
+                    let ch = CFStringGetCharacterAtIndex(display_name_ref, i);
+                    name_chars.push(std::char::from_u32(ch as u32).unwrap());
+                }
+                Some(name_chars.iter().cloned().collect::<String>())
+            },
+            _ => None
+        }
+    }
+}

--- a/examples/send-notes.rs
+++ b/examples/send-notes.rs
@@ -4,7 +4,7 @@ extern crate time;
 extern crate libc;
 
 use core_foundation::string::{CFString, CFStringRef, CFStringGetLength, UniChar};
-use core_foundation::base::{TCFType, CFIndex};
+use core_foundation::base::{TCFType, CFIndex, CFRelease};
 
 use coremidi_sys::{
     MIDIGetNumberOfDestinations, MIDIGetDestination,
@@ -148,6 +148,7 @@ fn get_display_name(endpoint: MIDIEndpointRef) -> Option<String> {
                     let ch = CFStringGetCharacterAtIndex(display_name_ref, i);
                     name_chars.push(std::char::from_u32(ch as u32).unwrap());
                 }
+                CFRelease(display_name_ref as *mut libc::c_void);
                 Some(name_chars.iter().cloned().collect::<String>())
             },
             _ => None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ pub type MIDICompletionProc =
     ::std::option::Option<extern "C" fn(request: *mut MIDISysexSendRequest)
                               -> ()>;
 #[repr(C)]
+#[repr(packed)]
 #[derive(Copy)]
 pub struct Struct_MIDIPacket {
     pub timeStamp: MIDITimeStamp,
@@ -90,6 +91,7 @@ impl ::std::default::Default for Struct_MIDIPacket {
 }
 pub type MIDIPacket = Struct_MIDIPacket;
 #[repr(C)]
+#[repr(packed)]
 #[derive(Copy)]
 pub struct Struct_MIDIPacketList {
     pub numPackets: UInt32,
@@ -102,6 +104,7 @@ impl ::std::default::Default for Struct_MIDIPacketList {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[repr(C)]
+#[repr(packed)]
 #[derive(Copy)]
 pub struct Struct_MIDISysexSendRequest {
     pub destination: MIDIEndpointRef,
@@ -128,6 +131,7 @@ pub const kMIDIMsgSerialPortOwnerChanged: ::libc::c_uint = 6;
 pub const kMIDIMsgIOError: ::libc::c_uint = 7;
 pub type MIDINotificationMessageID = SInt32;
 #[repr(C)]
+#[repr(packed)]
 #[derive(Copy)]
 pub struct Struct_MIDINotification {
     pub messageID: MIDINotificationMessageID,
@@ -140,6 +144,7 @@ impl ::std::default::Default for Struct_MIDINotification {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 #[repr(C)]
+#[repr(packed)]
 #[derive(Copy)]
 pub struct Struct_MIDIObjectAddRemoveNotification {
     pub messageID: MIDINotificationMessageID,
@@ -158,6 +163,7 @@ impl ::std::default::Default for Struct_MIDIObjectAddRemoveNotification {
 pub type MIDIObjectAddRemoveNotification =
     Struct_MIDIObjectAddRemoveNotification;
 #[repr(C)]
+#[repr(packed)]
 #[derive(Copy)]
 pub struct Struct_MIDIObjectPropertyChangeNotification {
     pub messageID: MIDINotificationMessageID,
@@ -175,6 +181,7 @@ impl ::std::default::Default for Struct_MIDIObjectPropertyChangeNotification {
 pub type MIDIObjectPropertyChangeNotification =
     Struct_MIDIObjectPropertyChangeNotification;
 #[repr(C)]
+#[repr(packed)]
 #[derive(Copy)]
 pub struct Struct_MIDIIOErrorNotification {
     pub messageID: MIDINotificationMessageID,
@@ -224,6 +231,7 @@ pub const kMIDIControlType_7BitNRPN: ::libc::c_uint = 4;
 pub const kMIDIControlType_14BitNRPN: ::libc::c_uint = 5;
 pub type MIDITransformControlType = UInt8;
 #[repr(C)]
+#[repr(packed)]
 #[derive(Copy)]
 pub struct Struct_MIDITransform {
     pub transform: MIDITransformType,
@@ -237,6 +245,7 @@ impl ::std::default::Default for Struct_MIDITransform {
 }
 pub type MIDITransform = Struct_MIDITransform;
 #[repr(C)]
+#[repr(packed)]
 #[derive(Copy)]
 pub struct Struct_MIDIControlTransform {
     pub controlType: MIDITransformControlType,
@@ -253,6 +262,7 @@ impl ::std::default::Default for Struct_MIDIControlTransform {
 }
 pub type MIDIControlTransform = Struct_MIDIControlTransform;
 #[repr(C)]
+#[repr(packed)]
 #[derive(Copy)]
 pub struct Struct_MIDIThruConnectionEndpoint {
     pub endpointRef: MIDIEndpointRef,
@@ -266,6 +276,7 @@ impl ::std::default::Default for Struct_MIDIThruConnectionEndpoint {
 }
 pub type MIDIThruConnectionEndpoint = Struct_MIDIThruConnectionEndpoint;
 #[repr(C)]
+#[repr(packed)]
 #[derive(Copy)]
 pub struct Struct_MIDIThruConnectionParams {
     pub version: UInt32,


### PR DESCRIPTION
After struggling a bit to get an example on how to send notes, I realised that there was a bug on how the structs were defined. The compiler was adding padding to them and breaking the CoreMIDI expected layout. By adding ```#[repr(packed)]``` before the struct definition, the compiler stopped to add padding and the example started to work.

@jonas-k let me know if you would rather separate the fix from the example.