### PR TITLE
Build nothing on non-Apple systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coremidi-sys"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Jonas Klesy", "Patrick Reisert"]
 description = "Low-level FFI bindings for the CoreMIDI framework"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coremidi-sys"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Jonas Klesy", "Patrick Reisert"]
 description = "Low-level FFI bindings for the CoreMIDI framework"
 license = "MIT"
@@ -8,7 +8,7 @@ repository = "https://github.com/jonas-k/coremidi-sys"
 documentation = "https://docs.rs/coremidi-sys"
 categories = ["external-ffi-bindings", "multimedia::audio"]
 
-[dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation-sys = "0.2"
 
 [package.metadata.docs.rs]

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
 fn main() {
-    println!("cargo:rustc-link-lib=framework=CoreMIDI");
+    if std::env::var("TARGET").expect("cannot read TARGET environment variable").contains("apple") {
+        println!("cargo:rustc-link-lib=framework=CoreMIDI");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg(any(target_os = "macos", target_os = "ios"))]
+
 #![allow(non_snake_case, non_upper_case_globals, non_camel_case_types)]
 
 extern crate core_foundation_sys;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ include!("generated.rs");
 pub unsafe fn MIDIPacketNext(pkt: *const MIDIPacket) -> *const MIDIPacket {
     let ptr = &(*pkt).data as *const u8;
     let offset = (*pkt).length as isize;
-    if cfg!(target_arch = "arm") {
+    if cfg!(any(target_arch = "arm", target_arch = "aarch64")) {
         // MIDIPacket must be 4-byte aligned on ARM
         ((ptr.offset(offset + 3) as usize) & !(3usize)) as *const MIDIPacket
     } else {


### PR DESCRIPTION
This just prevents the library from building and linking anything if the target system is not macOS or iOS. It also fixes the recognition of ARM64.

The changes have already been published as 2.0.2 on crates.io and fixes building on docs.rs, see e.g. https://docs.rs/coremidi-sys/2.0.1/x86_64-apple-darwin/coremidi_sys/