### PR TITLE
Regenerate bindings and update core-foundation-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coremidi-sys"
-version = "2.0.2"
+version = "3.0.0"
 authors = ["Jonas Klesy", "Patrick Reisert"]
 description = "Low-level FFI bindings for the CoreMIDI framework"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/coremidi-sys"
 categories = ["external-ffi-bindings", "multimedia::audio"]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-core-foundation-sys = "0.2"
+core-foundation-sys = "0.7.0"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Low level Rust bindings for CoreMIDI
 
-`generated.rs` is generated with rust-bindgen 0.26.3 using the following command:
+`generated.rs` is generated with [bindgen](https://github.com/rust-lang/rust-bindgen) 0.53.2 using the following command:
 ```
 bindgen /System/Library/Frameworks/CoreMIDI.framework/Headers/MIDIServices.h --whitelist-type "MIDI.*" --whitelist-function "MIDI.*"  --whitelist-var "kMIDI.*" --no-doc-comments --constified-enum ".*" --blacklist-type "(__)?CF.*" > src/generated.rs
 ```

--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ Low level Rust bindings for CoreMIDI
 
 `generated.rs` is generated with [bindgen](https://github.com/rust-lang/rust-bindgen) 0.53.2 using the following command:
 ```
-bindgen /System/Library/Frameworks/CoreMIDI.framework/Headers/MIDIServices.h --whitelist-type "MIDI.*" --whitelist-function "MIDI.*"  --whitelist-var "kMIDI.*" --no-doc-comments --constified-enum ".*" --blacklist-type "(__)?CF.*" > src/generated.rs
+bindgen /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreMIDI.framework/Headers/MIDIServices.h --whitelist-type "MIDI.*" --whitelist-function "MIDI.*"  --whitelist-var "kMIDI.*" --no-doc-comments --constified-enum ".*" --blacklist-type "(__)?CF.*" > src/generated.rs
 ```

--- a/src/generated.rs
+++ b/src/generated.rs
@@ -10,22 +10,23 @@ pub type ByteCount = ::std::os::raw::c_ulong;
 pub type ItemCount = ::std::os::raw::c_ulong;
 pub type Boolean = ::std::os::raw::c_uchar;
 pub type Byte = UInt8;
-pub const kMIDIInvalidClient: _bindgen_ty_64 = -10830;
-pub const kMIDIInvalidPort: _bindgen_ty_64 = -10831;
-pub const kMIDIWrongEndpointType: _bindgen_ty_64 = -10832;
-pub const kMIDINoConnection: _bindgen_ty_64 = -10833;
-pub const kMIDIUnknownEndpoint: _bindgen_ty_64 = -10834;
-pub const kMIDIUnknownProperty: _bindgen_ty_64 = -10835;
-pub const kMIDIWrongPropertyType: _bindgen_ty_64 = -10836;
-pub const kMIDINoCurrentSetup: _bindgen_ty_64 = -10837;
-pub const kMIDIMessageSendErr: _bindgen_ty_64 = -10838;
-pub const kMIDIServerStartErr: _bindgen_ty_64 = -10839;
-pub const kMIDISetupFormatErr: _bindgen_ty_64 = -10840;
-pub const kMIDIWrongThread: _bindgen_ty_64 = -10841;
-pub const kMIDIObjectNotFound: _bindgen_ty_64 = -10842;
-pub const kMIDIIDNotUnique: _bindgen_ty_64 = -10843;
-pub const kMIDINotPermitted: _bindgen_ty_64 = -10844;
-pub type _bindgen_ty_64 = ::std::os::raw::c_int;
+pub const kMIDIInvalidClient: _bindgen_ty_65 = -10830;
+pub const kMIDIInvalidPort: _bindgen_ty_65 = -10831;
+pub const kMIDIWrongEndpointType: _bindgen_ty_65 = -10832;
+pub const kMIDINoConnection: _bindgen_ty_65 = -10833;
+pub const kMIDIUnknownEndpoint: _bindgen_ty_65 = -10834;
+pub const kMIDIUnknownProperty: _bindgen_ty_65 = -10835;
+pub const kMIDIWrongPropertyType: _bindgen_ty_65 = -10836;
+pub const kMIDINoCurrentSetup: _bindgen_ty_65 = -10837;
+pub const kMIDIMessageSendErr: _bindgen_ty_65 = -10838;
+pub const kMIDIServerStartErr: _bindgen_ty_65 = -10839;
+pub const kMIDISetupFormatErr: _bindgen_ty_65 = -10840;
+pub const kMIDIWrongThread: _bindgen_ty_65 = -10841;
+pub const kMIDIObjectNotFound: _bindgen_ty_65 = -10842;
+pub const kMIDIIDNotUnique: _bindgen_ty_65 = -10843;
+pub const kMIDINotPermitted: _bindgen_ty_65 = -10844;
+pub const kMIDIUnknownError: _bindgen_ty_65 = -10845;
+pub type _bindgen_ty_65 = i32;
 pub type MIDIObjectRef = UInt32;
 pub type MIDIClientRef = MIDIObjectRef;
 pub type MIDIPortRef = MIDIObjectRef;
@@ -34,46 +35,125 @@ pub type MIDIEntityRef = MIDIObjectRef;
 pub type MIDIEndpointRef = MIDIObjectRef;
 pub type MIDITimeStamp = UInt64;
 pub type MIDIObjectType = SInt32;
-pub const kMIDIObjectType_Other: _bindgen_ty_65 = -1;
-pub const kMIDIObjectType_Device: _bindgen_ty_65 = 0;
-pub const kMIDIObjectType_Entity: _bindgen_ty_65 = 1;
-pub const kMIDIObjectType_Source: _bindgen_ty_65 = 2;
-pub const kMIDIObjectType_Destination: _bindgen_ty_65 = 3;
-pub const kMIDIObjectType_ExternalDevice: _bindgen_ty_65 = 16;
-pub const kMIDIObjectType_ExternalEntity: _bindgen_ty_65 = 17;
-pub const kMIDIObjectType_ExternalSource: _bindgen_ty_65 = 18;
-pub const kMIDIObjectType_ExternalDestination: _bindgen_ty_65 = 19;
-pub type _bindgen_ty_65 = ::std::os::raw::c_int;
+pub const kMIDIObjectType_Other: _bindgen_ty_66 = -1;
+pub const kMIDIObjectType_Device: _bindgen_ty_66 = 0;
+pub const kMIDIObjectType_Entity: _bindgen_ty_66 = 1;
+pub const kMIDIObjectType_Source: _bindgen_ty_66 = 2;
+pub const kMIDIObjectType_Destination: _bindgen_ty_66 = 3;
+pub const kMIDIObjectType_ExternalDevice: _bindgen_ty_66 = 16;
+pub const kMIDIObjectType_ExternalEntity: _bindgen_ty_66 = 17;
+pub const kMIDIObjectType_ExternalSource: _bindgen_ty_66 = 18;
+pub const kMIDIObjectType_ExternalDestination: _bindgen_ty_66 = 19;
+pub type _bindgen_ty_66 = i32;
 pub const kMIDIObjectType_ExternalMask: MIDIObjectType = 16;
 pub type MIDIUniqueID = SInt32;
-pub const kMIDIInvalidUniqueID: _bindgen_ty_66 = 0;
-pub type _bindgen_ty_66 = ::std::os::raw::c_uint;
+pub const kMIDIInvalidUniqueID: _bindgen_ty_67 = 0;
+pub type _bindgen_ty_67 = u32;
+pub type MIDINotifyProc = ::std::option::Option<
+    unsafe extern "C" fn(message: *const MIDINotification, refCon: *mut ::std::os::raw::c_void),
+>;
+pub type MIDINotifyBlock = *mut ::std::os::raw::c_void;
+pub type MIDIReadProc = ::std::option::Option<
+    unsafe extern "C" fn(
+        pktlist: *const MIDIPacketList,
+        readProcRefCon: *mut ::std::os::raw::c_void,
+        srcConnRefCon: *mut ::std::os::raw::c_void,
+    ),
+>;
+pub type MIDIReadBlock = *mut ::std::os::raw::c_void;
+pub type MIDICompletionProc =
+    ::std::option::Option<unsafe extern "C" fn(request: *mut MIDISysexSendRequest)>;
+#[repr(C, packed(4))]
+#[derive(Copy, Clone)]
+pub struct MIDIPacket {
+    pub timeStamp: MIDITimeStamp,
+    pub length: UInt16,
+    pub data: [Byte; 256usize],
+}
+#[test]
+fn bindgen_test_layout_MIDIPacket() {
+    assert_eq!(
+        ::std::mem::size_of::<MIDIPacket>(),
+        268usize,
+        concat!("Size of: ", stringify!(MIDIPacket))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<MIDIPacket>(),
+        4usize,
+        concat!("Alignment of ", stringify!(MIDIPacket))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<MIDIPacket>())).timeStamp as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIPacket),
+            "::",
+            stringify!(timeStamp)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<MIDIPacket>())).length as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIPacket),
+            "::",
+            stringify!(length)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<MIDIPacket>())).data as *const _ as usize },
+        10usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIPacket),
+            "::",
+            stringify!(data)
+        )
+    );
+}
 #[repr(C)]
-#[repr(packed)]
-//#[repr(pack(4))] would be correct, see https://github.com/rust-lang/rust/issues/33158
+#[derive(Copy, Clone)]
 pub struct MIDIPacketList {
     pub numPackets: UInt32,
     pub packet: [MIDIPacket; 1usize],
 }
 #[test]
 fn bindgen_test_layout_MIDIPacketList() {
-    assert_eq!(::std::mem::size_of::<MIDIPacketList>() , 272usize , concat ! (
-               "Size of: " , stringify ! ( MIDIPacketList ) ));
-    assert_eq! (::std::mem::align_of::<MIDIPacketList>() , 4usize , concat ! (
-                "Alignment of " , stringify ! ( MIDIPacketList ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIPacketList ) ) . numPackets as *
-                const _ as usize } , 0usize , concat ! (
-                "Alignment of field: " , stringify ! ( MIDIPacketList ) , "::"
-                , stringify ! ( numPackets ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIPacketList ) ) . packet as * const _
-                as usize } , 4usize , concat ! (
-                "Alignment of field: " , stringify ! ( MIDIPacketList ) , "::"
-                , stringify ! ( packet ) ));
+    assert_eq!(
+        ::std::mem::size_of::<MIDIPacketList>(),
+        272usize,
+        concat!("Size of: ", stringify!(MIDIPacketList))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<MIDIPacketList>(),
+        4usize,
+        concat!("Alignment of ", stringify!(MIDIPacketList))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<MIDIPacketList>())).numPackets as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIPacketList),
+            "::",
+            stringify!(numPackets)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<MIDIPacketList>())).packet as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIPacketList),
+            "::",
+            stringify!(packet)
+        )
+    );
 }
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct MIDISysexSendRequest {
     pub destination: MIDIEndpointRef,
     pub data: *const Byte,
@@ -85,136 +165,145 @@ pub struct MIDISysexSendRequest {
 }
 #[test]
 fn bindgen_test_layout_MIDISysexSendRequest() {
-    assert_eq!(::std::mem::size_of::<MIDISysexSendRequest>() , 40usize ,
-               concat ! ( "Size of: " , stringify ! ( MIDISysexSendRequest )
-               ));
-    assert_eq! (::std::mem::align_of::<MIDISysexSendRequest>() , 8usize ,
-                concat ! (
-                "Alignment of " , stringify ! ( MIDISysexSendRequest ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDISysexSendRequest ) ) . destination as
-                * const _ as usize } , 0usize , concat ! (
-                "Alignment of field: " , stringify ! ( MIDISysexSendRequest )
-                , "::" , stringify ! ( destination ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDISysexSendRequest ) ) . data as *
-                const _ as usize } , 8usize , concat ! (
-                "Alignment of field: " , stringify ! ( MIDISysexSendRequest )
-                , "::" , stringify ! ( data ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDISysexSendRequest ) ) . bytesToSend as
-                * const _ as usize } , 16usize , concat ! (
-                "Alignment of field: " , stringify ! ( MIDISysexSendRequest )
-                , "::" , stringify ! ( bytesToSend ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDISysexSendRequest ) ) . complete as *
-                const _ as usize } , 20usize , concat ! (
-                "Alignment of field: " , stringify ! ( MIDISysexSendRequest )
-                , "::" , stringify ! ( complete ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDISysexSendRequest ) ) . reserved as *
-                const _ as usize } , 21usize , concat ! (
-                "Alignment of field: " , stringify ! ( MIDISysexSendRequest )
-                , "::" , stringify ! ( reserved ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDISysexSendRequest ) ) . completionProc
-                as * const _ as usize } , 24usize , concat ! (
-                "Alignment of field: " , stringify ! ( MIDISysexSendRequest )
-                , "::" , stringify ! ( completionProc ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDISysexSendRequest ) ) .
-                completionRefCon as * const _ as usize } , 32usize , concat !
-                (
-                "Alignment of field: " , stringify ! ( MIDISysexSendRequest )
-                , "::" , stringify ! ( completionRefCon ) ));
+    assert_eq!(
+        ::std::mem::size_of::<MIDISysexSendRequest>(),
+        40usize,
+        concat!("Size of: ", stringify!(MIDISysexSendRequest))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<MIDISysexSendRequest>(),
+        8usize,
+        concat!("Alignment of ", stringify!(MIDISysexSendRequest))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDISysexSendRequest>())).destination as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDISysexSendRequest),
+            "::",
+            stringify!(destination)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<MIDISysexSendRequest>())).data as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDISysexSendRequest),
+            "::",
+            stringify!(data)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDISysexSendRequest>())).bytesToSend as *const _ as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDISysexSendRequest),
+            "::",
+            stringify!(bytesToSend)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<MIDISysexSendRequest>())).complete as *const _ as usize },
+        20usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDISysexSendRequest),
+            "::",
+            stringify!(complete)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<MIDISysexSendRequest>())).reserved as *const _ as usize },
+        21usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDISysexSendRequest),
+            "::",
+            stringify!(reserved)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDISysexSendRequest>())).completionProc as *const _ as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDISysexSendRequest),
+            "::",
+            stringify!(completionProc)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDISysexSendRequest>())).completionRefCon as *const _ as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDISysexSendRequest),
+            "::",
+            stringify!(completionRefCon)
+        )
+    );
 }
-impl Clone for MIDISysexSendRequest {
-    fn clone(&self) -> Self { *self }
-}
+pub type MIDINotificationMessageID = SInt32;
+pub const kMIDIMsgSetupChanged: _bindgen_ty_68 = 1;
+pub const kMIDIMsgObjectAdded: _bindgen_ty_68 = 2;
+pub const kMIDIMsgObjectRemoved: _bindgen_ty_68 = 3;
+pub const kMIDIMsgPropertyChanged: _bindgen_ty_68 = 4;
+pub const kMIDIMsgThruConnectionsChanged: _bindgen_ty_68 = 5;
+pub const kMIDIMsgSerialPortOwnerChanged: _bindgen_ty_68 = 6;
+pub const kMIDIMsgIOError: _bindgen_ty_68 = 7;
+pub type _bindgen_ty_68 = u32;
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct MIDINotification {
     pub messageID: MIDINotificationMessageID,
     pub messageSize: UInt32,
 }
 #[test]
 fn bindgen_test_layout_MIDINotification() {
-    assert_eq!(::std::mem::size_of::<MIDINotification>() , 8usize , concat ! (
-               "Size of: " , stringify ! ( MIDINotification ) ));
-    assert_eq! (::std::mem::align_of::<MIDINotification>() , 4usize , concat !
-                ( "Alignment of " , stringify ! ( MIDINotification ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDINotification ) ) . messageID as *
-                const _ as usize } , 0usize , concat ! (
-                "Alignment of field: " , stringify ! ( MIDINotification ) ,
-                "::" , stringify ! ( messageID ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDINotification ) ) . messageSize as *
-                const _ as usize } , 4usize , concat ! (
-                "Alignment of field: " , stringify ! ( MIDINotification ) ,
-                "::" , stringify ! ( messageSize ) ));
+    assert_eq!(
+        ::std::mem::size_of::<MIDINotification>(),
+        8usize,
+        concat!("Size of: ", stringify!(MIDINotification))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<MIDINotification>(),
+        4usize,
+        concat!("Alignment of ", stringify!(MIDINotification))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<MIDINotification>())).messageID as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDINotification),
+            "::",
+            stringify!(messageID)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<MIDINotification>())).messageSize as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDINotification),
+            "::",
+            stringify!(messageSize)
+        )
+    );
 }
-impl Clone for MIDINotification {
-    fn clone(&self) -> Self { *self }
-}
-pub type MIDINotifyProc =
-    ::std::option::Option<unsafe extern "C" fn(message:
-                                                   *const MIDINotification,
-                                               refCon:
-                                                   *mut ::std::os::raw::c_void)>;
-pub type MIDINotifyBlock = *mut ::std::os::raw::c_void;
-pub type MIDIReadProc =
-    ::std::option::Option<unsafe extern "C" fn(pktlist: *const MIDIPacketList,
-                                               readProcRefCon:
-                                                   *mut ::std::os::raw::c_void,
-                                               srcConnRefCon:
-                                                   *mut ::std::os::raw::c_void)>;
-pub type MIDIReadBlock = *mut ::std::os::raw::c_void;
-pub type MIDICompletionProc =
-    ::std::option::Option<unsafe extern "C" fn(request:
-                                                   *mut MIDISysexSendRequest)>;
 #[repr(C)]
-#[repr(packed)]
-//#[repr(pack(4))] would be correct, see https://github.com/rust-lang/rust/issues/33158
-pub struct MIDIPacket {
-    pub timeStamp: MIDITimeStamp,
-    pub length: UInt16,
-    pub data: [Byte; 256usize],
-    pub __padding: [Byte; 2usize]
-}
-#[test]
-fn bindgen_test_layout_MIDIPacket() {
-    assert_eq!(::std::mem::size_of::<MIDIPacket>() , 268usize , concat ! (
-               "Size of: " , stringify ! ( MIDIPacket ) ));
-    assert_eq! (::std::mem::align_of::<MIDIPacket>() , 4usize , concat ! (
-                "Alignment of " , stringify ! ( MIDIPacket ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIPacket ) ) . timeStamp as * const _
-                as usize } , 0usize , concat ! (
-                "Alignment of field: " , stringify ! ( MIDIPacket ) , "::" ,
-                stringify ! ( timeStamp ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIPacket ) ) . length as * const _ as
-                usize } , 8usize , concat ! (
-                "Alignment of field: " , stringify ! ( MIDIPacket ) , "::" ,
-                stringify ! ( length ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIPacket ) ) . data as * const _ as
-                usize } , 10usize , concat ! (
-                "Alignment of field: " , stringify ! ( MIDIPacket ) , "::" ,
-                stringify ! ( data ) ));
-}
-pub type MIDINotificationMessageID = SInt32;
-pub const kMIDIMsgSetupChanged: _bindgen_ty_67 = 1;
-pub const kMIDIMsgObjectAdded: _bindgen_ty_67 = 2;
-pub const kMIDIMsgObjectRemoved: _bindgen_ty_67 = 3;
-pub const kMIDIMsgPropertyChanged: _bindgen_ty_67 = 4;
-pub const kMIDIMsgThruConnectionsChanged: _bindgen_ty_67 = 5;
-pub const kMIDIMsgSerialPortOwnerChanged: _bindgen_ty_67 = 6;
-pub const kMIDIMsgIOError: _bindgen_ty_67 = 7;
-pub type _bindgen_ty_67 = ::std::os::raw::c_uint;
-#[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct MIDIObjectAddRemoveNotification {
     pub messageID: MIDINotificationMessageID,
     pub messageSize: UInt32,
@@ -225,56 +314,94 @@ pub struct MIDIObjectAddRemoveNotification {
 }
 #[test]
 fn bindgen_test_layout_MIDIObjectAddRemoveNotification() {
-    assert_eq!(::std::mem::size_of::<MIDIObjectAddRemoveNotification>() ,
-               24usize , concat ! (
-               "Size of: " , stringify ! ( MIDIObjectAddRemoveNotification )
-               ));
-    assert_eq! (::std::mem::align_of::<MIDIObjectAddRemoveNotification>() ,
-                4usize , concat ! (
-                "Alignment of " , stringify ! (
-                MIDIObjectAddRemoveNotification ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIObjectAddRemoveNotification ) ) .
-                messageID as * const _ as usize } , 0usize , concat ! (
-                "Alignment of field: " , stringify ! (
-                MIDIObjectAddRemoveNotification ) , "::" , stringify ! (
-                messageID ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIObjectAddRemoveNotification ) ) .
-                messageSize as * const _ as usize } , 4usize , concat ! (
-                "Alignment of field: " , stringify ! (
-                MIDIObjectAddRemoveNotification ) , "::" , stringify ! (
-                messageSize ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIObjectAddRemoveNotification ) ) .
-                parent as * const _ as usize } , 8usize , concat ! (
-                "Alignment of field: " , stringify ! (
-                MIDIObjectAddRemoveNotification ) , "::" , stringify ! (
-                parent ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIObjectAddRemoveNotification ) ) .
-                parentType as * const _ as usize } , 12usize , concat ! (
-                "Alignment of field: " , stringify ! (
-                MIDIObjectAddRemoveNotification ) , "::" , stringify ! (
-                parentType ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIObjectAddRemoveNotification ) ) .
-                child as * const _ as usize } , 16usize , concat ! (
-                "Alignment of field: " , stringify ! (
-                MIDIObjectAddRemoveNotification ) , "::" , stringify ! ( child
-                ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIObjectAddRemoveNotification ) ) .
-                childType as * const _ as usize } , 20usize , concat ! (
-                "Alignment of field: " , stringify ! (
-                MIDIObjectAddRemoveNotification ) , "::" , stringify ! (
-                childType ) ));
-}
-impl Clone for MIDIObjectAddRemoveNotification {
-    fn clone(&self) -> Self { *self }
+    assert_eq!(
+        ::std::mem::size_of::<MIDIObjectAddRemoveNotification>(),
+        24usize,
+        concat!("Size of: ", stringify!(MIDIObjectAddRemoveNotification))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<MIDIObjectAddRemoveNotification>(),
+        4usize,
+        concat!("Alignment of ", stringify!(MIDIObjectAddRemoveNotification))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDIObjectAddRemoveNotification>())).messageID as *const _
+                as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIObjectAddRemoveNotification),
+            "::",
+            stringify!(messageID)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDIObjectAddRemoveNotification>())).messageSize as *const _
+                as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIObjectAddRemoveNotification),
+            "::",
+            stringify!(messageSize)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDIObjectAddRemoveNotification>())).parent as *const _ as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIObjectAddRemoveNotification),
+            "::",
+            stringify!(parent)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDIObjectAddRemoveNotification>())).parentType as *const _
+                as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIObjectAddRemoveNotification),
+            "::",
+            stringify!(parentType)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDIObjectAddRemoveNotification>())).child as *const _ as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIObjectAddRemoveNotification),
+            "::",
+            stringify!(child)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDIObjectAddRemoveNotification>())).childType as *const _
+                as usize
+        },
+        20usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIObjectAddRemoveNotification),
+            "::",
+            stringify!(childType)
+        )
+    );
 }
 #[repr(C)]
-#[derive(Debug, Copy)]
 pub struct MIDIObjectPropertyChangeNotification {
     pub messageID: MIDINotificationMessageID,
     pub messageSize: UInt32,
@@ -284,50 +411,90 @@ pub struct MIDIObjectPropertyChangeNotification {
 }
 #[test]
 fn bindgen_test_layout_MIDIObjectPropertyChangeNotification() {
-    assert_eq!(::std::mem::size_of::<MIDIObjectPropertyChangeNotification>() ,
-               24usize , concat ! (
-               "Size of: " , stringify ! (
-               MIDIObjectPropertyChangeNotification ) ));
-    assert_eq! (::std::mem::align_of::<MIDIObjectPropertyChangeNotification>()
-                , 8usize , concat ! (
-                "Alignment of " , stringify ! (
-                MIDIObjectPropertyChangeNotification ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIObjectPropertyChangeNotification ) )
-                . messageID as * const _ as usize } , 0usize , concat ! (
-                "Alignment of field: " , stringify ! (
-                MIDIObjectPropertyChangeNotification ) , "::" , stringify ! (
-                messageID ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIObjectPropertyChangeNotification ) )
-                . messageSize as * const _ as usize } , 4usize , concat ! (
-                "Alignment of field: " , stringify ! (
-                MIDIObjectPropertyChangeNotification ) , "::" , stringify ! (
-                messageSize ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIObjectPropertyChangeNotification ) )
-                . object as * const _ as usize } , 8usize , concat ! (
-                "Alignment of field: " , stringify ! (
-                MIDIObjectPropertyChangeNotification ) , "::" , stringify ! (
-                object ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIObjectPropertyChangeNotification ) )
-                . objectType as * const _ as usize } , 12usize , concat ! (
-                "Alignment of field: " , stringify ! (
-                MIDIObjectPropertyChangeNotification ) , "::" , stringify ! (
-                objectType ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIObjectPropertyChangeNotification ) )
-                . propertyName as * const _ as usize } , 16usize , concat ! (
-                "Alignment of field: " , stringify ! (
-                MIDIObjectPropertyChangeNotification ) , "::" , stringify ! (
-                propertyName ) ));
-}
-impl Clone for MIDIObjectPropertyChangeNotification {
-    fn clone(&self) -> Self { *self }
+    assert_eq!(
+        ::std::mem::size_of::<MIDIObjectPropertyChangeNotification>(),
+        24usize,
+        concat!(
+            "Size of: ",
+            stringify!(MIDIObjectPropertyChangeNotification)
+        )
+    );
+    assert_eq!(
+        ::std::mem::align_of::<MIDIObjectPropertyChangeNotification>(),
+        8usize,
+        concat!(
+            "Alignment of ",
+            stringify!(MIDIObjectPropertyChangeNotification)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDIObjectPropertyChangeNotification>())).messageID as *const _
+                as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIObjectPropertyChangeNotification),
+            "::",
+            stringify!(messageID)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDIObjectPropertyChangeNotification>())).messageSize as *const _
+                as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIObjectPropertyChangeNotification),
+            "::",
+            stringify!(messageSize)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDIObjectPropertyChangeNotification>())).object as *const _
+                as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIObjectPropertyChangeNotification),
+            "::",
+            stringify!(object)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDIObjectPropertyChangeNotification>())).objectType as *const _
+                as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIObjectPropertyChangeNotification),
+            "::",
+            stringify!(objectType)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDIObjectPropertyChangeNotification>())).propertyName
+                as *const _ as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIObjectPropertyChangeNotification),
+            "::",
+            stringify!(propertyName)
+        )
+    );
 }
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct MIDIIOErrorNotification {
     pub messageID: MIDINotificationMessageID,
     pub messageSize: UInt32,
@@ -336,261 +503,260 @@ pub struct MIDIIOErrorNotification {
 }
 #[test]
 fn bindgen_test_layout_MIDIIOErrorNotification() {
-    assert_eq!(::std::mem::size_of::<MIDIIOErrorNotification>() , 16usize ,
-               concat ! (
-               "Size of: " , stringify ! ( MIDIIOErrorNotification ) ));
-    assert_eq! (::std::mem::align_of::<MIDIIOErrorNotification>() , 4usize ,
-                concat ! (
-                "Alignment of " , stringify ! ( MIDIIOErrorNotification ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIIOErrorNotification ) ) . messageID
-                as * const _ as usize } , 0usize , concat ! (
-                "Alignment of field: " , stringify ! ( MIDIIOErrorNotification
-                ) , "::" , stringify ! ( messageID ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIIOErrorNotification ) ) . messageSize
-                as * const _ as usize } , 4usize , concat ! (
-                "Alignment of field: " , stringify ! ( MIDIIOErrorNotification
-                ) , "::" , stringify ! ( messageSize ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIIOErrorNotification ) ) .
-                driverDevice as * const _ as usize } , 8usize , concat ! (
-                "Alignment of field: " , stringify ! ( MIDIIOErrorNotification
-                ) , "::" , stringify ! ( driverDevice ) ));
-    assert_eq! (unsafe {
-                & ( * ( 0 as * const MIDIIOErrorNotification ) ) . errorCode
-                as * const _ as usize } , 12usize , concat ! (
-                "Alignment of field: " , stringify ! ( MIDIIOErrorNotification
-                ) , "::" , stringify ! ( errorCode ) ));
-}
-impl Clone for MIDIIOErrorNotification {
-    fn clone(&self) -> Self { *self }
+    assert_eq!(
+        ::std::mem::size_of::<MIDIIOErrorNotification>(),
+        16usize,
+        concat!("Size of: ", stringify!(MIDIIOErrorNotification))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<MIDIIOErrorNotification>(),
+        4usize,
+        concat!("Alignment of ", stringify!(MIDIIOErrorNotification))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDIIOErrorNotification>())).messageID as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIIOErrorNotification),
+            "::",
+            stringify!(messageID)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDIIOErrorNotification>())).messageSize as *const _ as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIIOErrorNotification),
+            "::",
+            stringify!(messageSize)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDIIOErrorNotification>())).driverDevice as *const _ as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIIOErrorNotification),
+            "::",
+            stringify!(driverDevice)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<MIDIIOErrorNotification>())).errorCode as *const _ as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MIDIIOErrorNotification),
+            "::",
+            stringify!(errorCode)
+        )
+    );
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyName"]
     pub static kMIDIPropertyName: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyManufacturer"]
     pub static kMIDIPropertyManufacturer: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyModel"]
     pub static kMIDIPropertyModel: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyUniqueID"]
     pub static kMIDIPropertyUniqueID: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyDeviceID"]
     pub static kMIDIPropertyDeviceID: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyReceiveChannels"]
     pub static kMIDIPropertyReceiveChannels: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyTransmitChannels"]
     pub static kMIDIPropertyTransmitChannels: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyMaxSysExSpeed"]
     pub static kMIDIPropertyMaxSysExSpeed: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyAdvanceScheduleTimeMuSec"]
     pub static kMIDIPropertyAdvanceScheduleTimeMuSec: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyIsEmbeddedEntity"]
     pub static kMIDIPropertyIsEmbeddedEntity: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyIsBroadcast"]
     pub static kMIDIPropertyIsBroadcast: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertySingleRealtimeEntity"]
     pub static kMIDIPropertySingleRealtimeEntity: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyConnectionUniqueID"]
     pub static kMIDIPropertyConnectionUniqueID: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyOffline"]
     pub static kMIDIPropertyOffline: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyPrivate"]
     pub static kMIDIPropertyPrivate: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyDriverOwner"]
     pub static kMIDIPropertyDriverOwner: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyFactoryPatchNameFile"]
     pub static kMIDIPropertyFactoryPatchNameFile: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyUserPatchNameFile"]
     pub static kMIDIPropertyUserPatchNameFile: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyNameConfiguration"]
     pub static kMIDIPropertyNameConfiguration: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyImage"]
+    pub static kMIDIPropertyNameConfigurationDictionary: CFStringRef;
+}
+extern "C" {
     pub static kMIDIPropertyImage: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyDriverVersion"]
     pub static kMIDIPropertyDriverVersion: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertySupportsGeneralMIDI"]
     pub static kMIDIPropertySupportsGeneralMIDI: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertySupportsMMC"]
     pub static kMIDIPropertySupportsMMC: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyCanRoute"]
     pub static kMIDIPropertyCanRoute: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyReceivesClock"]
     pub static kMIDIPropertyReceivesClock: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyReceivesMTC"]
     pub static kMIDIPropertyReceivesMTC: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyReceivesNotes"]
     pub static kMIDIPropertyReceivesNotes: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyReceivesProgramChanges"]
     pub static kMIDIPropertyReceivesProgramChanges: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyReceivesBankSelectMSB"]
     pub static kMIDIPropertyReceivesBankSelectMSB: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyReceivesBankSelectLSB"]
     pub static kMIDIPropertyReceivesBankSelectLSB: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyTransmitsClock"]
     pub static kMIDIPropertyTransmitsClock: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyTransmitsMTC"]
     pub static kMIDIPropertyTransmitsMTC: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyTransmitsNotes"]
     pub static kMIDIPropertyTransmitsNotes: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyTransmitsProgramChanges"]
     pub static kMIDIPropertyTransmitsProgramChanges: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyTransmitsBankSelectMSB"]
     pub static kMIDIPropertyTransmitsBankSelectMSB: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyTransmitsBankSelectLSB"]
     pub static kMIDIPropertyTransmitsBankSelectLSB: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyPanDisruptsStereo"]
     pub static kMIDIPropertyPanDisruptsStereo: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyIsSampler"]
     pub static kMIDIPropertyIsSampler: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyIsDrumMachine"]
     pub static kMIDIPropertyIsDrumMachine: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyIsMixer"]
     pub static kMIDIPropertyIsMixer: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyIsEffectUnit"]
     pub static kMIDIPropertyIsEffectUnit: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyMaxReceiveChannels"]
     pub static kMIDIPropertyMaxReceiveChannels: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyMaxTransmitChannels"]
     pub static kMIDIPropertyMaxTransmitChannels: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyDriverDeviceEditorApp"]
     pub static kMIDIPropertyDriverDeviceEditorApp: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertySupportsShowControl"]
     pub static kMIDIPropertySupportsShowControl: CFStringRef;
 }
 extern "C" {
-    #[link_name = "kMIDIPropertyDisplayName"]
     pub static kMIDIPropertyDisplayName: CFStringRef;
 }
 extern "C" {
-    pub fn MIDIClientCreate(name: CFStringRef, notifyProc: MIDINotifyProc,
-                            notifyRefCon: *mut ::std::os::raw::c_void,
-                            outClient: *mut MIDIClientRef) -> OSStatus;
+    pub fn MIDIClientCreate(
+        name: CFStringRef,
+        notifyProc: MIDINotifyProc,
+        notifyRefCon: *mut ::std::os::raw::c_void,
+        outClient: *mut MIDIClientRef,
+    ) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIClientCreateWithBlock(name: CFStringRef,
-                                     outClient: *mut MIDIClientRef,
-                                     notifyBlock: MIDINotifyBlock)
-     -> OSStatus;
+    pub fn MIDIClientCreateWithBlock(
+        name: CFStringRef,
+        outClient: *mut MIDIClientRef,
+        notifyBlock: MIDINotifyBlock,
+    ) -> OSStatus;
 }
 extern "C" {
     pub fn MIDIClientDispose(client: MIDIClientRef) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIInputPortCreate(client: MIDIClientRef, portName: CFStringRef,
-                               readProc: MIDIReadProc,
-                               refCon: *mut ::std::os::raw::c_void,
-                               outPort: *mut MIDIPortRef) -> OSStatus;
+    pub fn MIDIInputPortCreate(
+        client: MIDIClientRef,
+        portName: CFStringRef,
+        readProc: MIDIReadProc,
+        refCon: *mut ::std::os::raw::c_void,
+        outPort: *mut MIDIPortRef,
+    ) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIInputPortCreateWithBlock(client: MIDIClientRef,
-                                        portName: CFStringRef,
-                                        outPort: *mut MIDIPortRef,
-                                        readBlock: MIDIReadBlock) -> OSStatus;
+    pub fn MIDIInputPortCreateWithBlock(
+        client: MIDIClientRef,
+        portName: CFStringRef,
+        outPort: *mut MIDIPortRef,
+        readBlock: MIDIReadBlock,
+    ) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIOutputPortCreate(client: MIDIClientRef, portName: CFStringRef,
-                                outPort: *mut MIDIPortRef) -> OSStatus;
+    pub fn MIDIOutputPortCreate(
+        client: MIDIClientRef,
+        portName: CFStringRef,
+        outPort: *mut MIDIPortRef,
+    ) -> OSStatus;
 }
 extern "C" {
     pub fn MIDIPortDispose(port: MIDIPortRef) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIPortConnectSource(port: MIDIPortRef, source: MIDIEndpointRef,
-                                 connRefCon: *mut ::std::os::raw::c_void)
-     -> OSStatus;
+    pub fn MIDIPortConnectSource(
+        port: MIDIPortRef,
+        source: MIDIEndpointRef,
+        connRefCon: *mut ::std::os::raw::c_void,
+    ) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIPortDisconnectSource(port: MIDIPortRef,
-                                    source: MIDIEndpointRef) -> OSStatus;
+    pub fn MIDIPortDisconnectSource(port: MIDIPortRef, source: MIDIEndpointRef) -> OSStatus;
 }
 extern "C" {
     pub fn MIDIGetNumberOfDevices() -> ItemCount;
@@ -602,27 +768,25 @@ extern "C" {
     pub fn MIDIDeviceGetNumberOfEntities(device: MIDIDeviceRef) -> ItemCount;
 }
 extern "C" {
-    pub fn MIDIDeviceGetEntity(device: MIDIDeviceRef, entityIndex0: ItemCount)
-     -> MIDIEntityRef;
+    pub fn MIDIDeviceGetEntity(device: MIDIDeviceRef, entityIndex0: ItemCount) -> MIDIEntityRef;
 }
 extern "C" {
     pub fn MIDIEntityGetNumberOfSources(entity: MIDIEntityRef) -> ItemCount;
 }
 extern "C" {
-    pub fn MIDIEntityGetSource(entity: MIDIEntityRef, sourceIndex0: ItemCount)
-     -> MIDIEndpointRef;
+    pub fn MIDIEntityGetSource(entity: MIDIEntityRef, sourceIndex0: ItemCount) -> MIDIEndpointRef;
 }
 extern "C" {
-    pub fn MIDIEntityGetNumberOfDestinations(entity: MIDIEntityRef)
-     -> ItemCount;
+    pub fn MIDIEntityGetNumberOfDestinations(entity: MIDIEntityRef) -> ItemCount;
 }
 extern "C" {
-    pub fn MIDIEntityGetDestination(entity: MIDIEntityRef,
-                                    destIndex0: ItemCount) -> MIDIEndpointRef;
+    pub fn MIDIEntityGetDestination(
+        entity: MIDIEntityRef,
+        destIndex0: ItemCount,
+    ) -> MIDIEndpointRef;
 }
 extern "C" {
-    pub fn MIDIEntityGetDevice(inEntity: MIDIEntityRef,
-                               outDevice: *mut MIDIDeviceRef) -> OSStatus;
+    pub fn MIDIEntityGetDevice(inEntity: MIDIEntityRef, outDevice: *mut MIDIDeviceRef) -> OSStatus;
 }
 extern "C" {
     pub fn MIDIGetNumberOfSources() -> ItemCount;
@@ -637,25 +801,34 @@ extern "C" {
     pub fn MIDIGetDestination(destIndex0: ItemCount) -> MIDIEndpointRef;
 }
 extern "C" {
-    pub fn MIDIEndpointGetEntity(inEndpoint: MIDIEndpointRef,
-                                 outEntity: *mut MIDIEntityRef) -> OSStatus;
+    pub fn MIDIEndpointGetEntity(
+        inEndpoint: MIDIEndpointRef,
+        outEntity: *mut MIDIEntityRef,
+    ) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIDestinationCreate(client: MIDIClientRef, name: CFStringRef,
-                                 readProc: MIDIReadProc,
-                                 refCon: *mut ::std::os::raw::c_void,
-                                 outDest: *mut MIDIEndpointRef) -> OSStatus;
+    pub fn MIDIDestinationCreate(
+        client: MIDIClientRef,
+        name: CFStringRef,
+        readProc: MIDIReadProc,
+        refCon: *mut ::std::os::raw::c_void,
+        outDest: *mut MIDIEndpointRef,
+    ) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIDestinationCreateWithBlock(client: MIDIClientRef,
-                                          name: CFStringRef,
-                                          outDest: *mut MIDIEndpointRef,
-                                          readBlock: MIDIReadBlock)
-     -> OSStatus;
+    pub fn MIDIDestinationCreateWithBlock(
+        client: MIDIClientRef,
+        name: CFStringRef,
+        outDest: *mut MIDIEndpointRef,
+        readBlock: MIDIReadBlock,
+    ) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDISourceCreate(client: MIDIClientRef, name: CFStringRef,
-                            outSrc: *mut MIDIEndpointRef) -> OSStatus;
+    pub fn MIDISourceCreate(
+        client: MIDIClientRef,
+        name: CFStringRef,
+        outSrc: *mut MIDIEndpointRef,
+    ) -> OSStatus;
 }
 extern "C" {
     pub fn MIDIEndpointDispose(endpt: MIDIEndpointRef) -> OSStatus;
@@ -667,71 +840,90 @@ extern "C" {
     pub fn MIDIGetExternalDevice(deviceIndex0: ItemCount) -> MIDIDeviceRef;
 }
 extern "C" {
-    pub fn MIDIObjectGetIntegerProperty(obj: MIDIObjectRef,
-                                        propertyID: CFStringRef,
-                                        outValue: *mut SInt32) -> OSStatus;
+    pub fn MIDIObjectGetIntegerProperty(
+        obj: MIDIObjectRef,
+        propertyID: CFStringRef,
+        outValue: *mut SInt32,
+    ) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIObjectSetIntegerProperty(obj: MIDIObjectRef,
-                                        propertyID: CFStringRef,
-                                        value: SInt32) -> OSStatus;
+    pub fn MIDIObjectSetIntegerProperty(
+        obj: MIDIObjectRef,
+        propertyID: CFStringRef,
+        value: SInt32,
+    ) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIObjectGetStringProperty(obj: MIDIObjectRef,
-                                       propertyID: CFStringRef,
-                                       str: *mut CFStringRef) -> OSStatus;
+    pub fn MIDIObjectGetStringProperty(
+        obj: MIDIObjectRef,
+        propertyID: CFStringRef,
+        str: *mut CFStringRef,
+    ) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIObjectSetStringProperty(obj: MIDIObjectRef,
-                                       propertyID: CFStringRef,
-                                       str: CFStringRef) -> OSStatus;
+    pub fn MIDIObjectSetStringProperty(
+        obj: MIDIObjectRef,
+        propertyID: CFStringRef,
+        str: CFStringRef,
+    ) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIObjectGetDataProperty(obj: MIDIObjectRef,
-                                     propertyID: CFStringRef,
-                                     outData: *mut CFDataRef) -> OSStatus;
+    pub fn MIDIObjectGetDataProperty(
+        obj: MIDIObjectRef,
+        propertyID: CFStringRef,
+        outData: *mut CFDataRef,
+    ) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIObjectSetDataProperty(obj: MIDIObjectRef,
-                                     propertyID: CFStringRef, data: CFDataRef)
-     -> OSStatus;
+    pub fn MIDIObjectSetDataProperty(
+        obj: MIDIObjectRef,
+        propertyID: CFStringRef,
+        data: CFDataRef,
+    ) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIObjectGetDictionaryProperty(obj: MIDIObjectRef,
-                                           propertyID: CFStringRef,
-                                           outDict: *mut CFDictionaryRef)
-     -> OSStatus;
+    pub fn MIDIObjectGetDictionaryProperty(
+        obj: MIDIObjectRef,
+        propertyID: CFStringRef,
+        outDict: *mut CFDictionaryRef,
+    ) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIObjectSetDictionaryProperty(obj: MIDIObjectRef,
-                                           propertyID: CFStringRef,
-                                           dict: CFDictionaryRef) -> OSStatus;
+    pub fn MIDIObjectSetDictionaryProperty(
+        obj: MIDIObjectRef,
+        propertyID: CFStringRef,
+        dict: CFDictionaryRef,
+    ) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIObjectGetProperties(obj: MIDIObjectRef,
-                                   outProperties: *mut CFPropertyListRef,
-                                   deep: Boolean) -> OSStatus;
+    pub fn MIDIObjectGetProperties(
+        obj: MIDIObjectRef,
+        outProperties: *mut CFPropertyListRef,
+        deep: Boolean,
+    ) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIObjectRemoveProperty(obj: MIDIObjectRef,
-                                    propertyID: CFStringRef) -> OSStatus;
+    pub fn MIDIObjectRemoveProperty(obj: MIDIObjectRef, propertyID: CFStringRef) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIObjectFindByUniqueID(inUniqueID: MIDIUniqueID,
-                                    outObject: *mut MIDIObjectRef,
-                                    outObjectType: *mut MIDIObjectType)
-     -> OSStatus;
+    pub fn MIDIObjectFindByUniqueID(
+        inUniqueID: MIDIUniqueID,
+        outObject: *mut MIDIObjectRef,
+        outObjectType: *mut MIDIObjectType,
+    ) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDISend(port: MIDIPortRef, dest: MIDIEndpointRef,
-                    pktlist: *const MIDIPacketList) -> OSStatus;
+    pub fn MIDISend(
+        port: MIDIPortRef,
+        dest: MIDIEndpointRef,
+        pktlist: *const MIDIPacketList,
+    ) -> OSStatus;
 }
 extern "C" {
     pub fn MIDISendSysex(request: *mut MIDISysexSendRequest) -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIReceived(src: MIDIEndpointRef, pktlist: *const MIDIPacketList)
-     -> OSStatus;
+    pub fn MIDIReceived(src: MIDIEndpointRef, pktlist: *const MIDIPacketList) -> OSStatus;
 }
 extern "C" {
     pub fn MIDIFlushOutput(dest: MIDIEndpointRef) -> OSStatus;
@@ -740,12 +932,15 @@ extern "C" {
     pub fn MIDIRestart() -> OSStatus;
 }
 extern "C" {
-    pub fn MIDIPacketListInit(pktlist: *mut MIDIPacketList)
-     -> *mut MIDIPacket;
+    pub fn MIDIPacketListInit(pktlist: *mut MIDIPacketList) -> *mut MIDIPacket;
 }
 extern "C" {
-    pub fn MIDIPacketListAdd(pktlist: *mut MIDIPacketList,
-                             listSize: ByteCount, curPacket: *mut MIDIPacket,
-                             time: MIDITimeStamp, nData: ByteCount,
-                             data: *const Byte) -> *mut MIDIPacket;
+    pub fn MIDIPacketListAdd(
+        pktlist: *mut MIDIPacketList,
+        listSize: ByteCount,
+        curPacket: *mut MIDIPacket,
+        time: MIDITimeStamp,
+        nData: ByteCount,
+        data: *const Byte,
+    ) -> *mut MIDIPacket;
 }


### PR DESCRIPTION
Hi there! This PR:
- Regenerates the bindings with bindgen 0.53.2, which seems to have generated slightly different bindings, formatted the output, and added `Clone` derives for structs
- Regenerates the bindings based on the macOS 10.14 SDK
- Updates `core-foundation-sys` to 0.7 to take advantage of improvements since 2015

Something worth noting is that the new bindgen adds `packed(4)` to `MIDIPacket`, which will bump the minimum rust version to 1.33 at least. It seems like it would fix https://github.com/jonas-k/coremidi-sys/issues/6, though!

One thing that confused me is that bindgen did _not_ add `packed(4)` to `MidiPacketList`, despite it being in the `#pragma` in `MIDIServices.h`. I am not sure why this is, and am honestly not familiar enough with the intricacies of type layout to trust that it's doing the right thing. I followed @Boddlnagg 's message in the existing bindings and added it manually, but I would appreciate another set of eyes to make sure that it's right. In fact, another set of eyes on the whole set of changes to the bindings would be really handy.

At least because of the `core-foundation-sys` version bump, I believe this would be a breaking change.

Thanks so much! 🙏 