### PR TITLE
Remove Copy & Clone from MIDIPacket & MIDIPacketList

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ Low level Rust bindings for CoreMIDI
 
 `generated.rs` is generated with [bindgen](https://github.com/rust-lang/rust-bindgen) 0.53.2 using the following command:
 ```
-bindgen /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreMIDI.framework/Headers/MIDIServices.h --whitelist-type "MIDI.*" --whitelist-function "MIDI.*"  --whitelist-var "kMIDI.*" --no-doc-comments --constified-enum ".*" --blacklist-type "(__)?CF.*" > src/generated.rs
+bindgen /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreMIDI.framework/Headers/MIDIServices.h --whitelist-type "MIDI.*" --whitelist-function "MIDI.*"  --whitelist-var "kMIDI.*" --no-doc-comments --constified-enum ".*" --no-copy "MIDIPacket.*" --blacklist-type "(__)?CF.*" > src/generated.rs
 ```

--- a/src/generated.rs
+++ b/src/generated.rs
@@ -64,7 +64,6 @@ pub type MIDIReadBlock = *mut ::std::os::raw::c_void;
 pub type MIDICompletionProc =
     ::std::option::Option<unsafe extern "C" fn(request: *mut MIDISysexSendRequest)>;
 #[repr(C, packed(4))]
-#[derive(Copy, Clone)]
 pub struct MIDIPacket {
     pub timeStamp: MIDITimeStamp,
     pub length: UInt16,
@@ -114,7 +113,6 @@ fn bindgen_test_layout_MIDIPacket() {
     );
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
 pub struct MIDIPacketList {
     pub numPackets: UInt32,
     pub packet: [MIDIPacket; 1usize],


### PR DESCRIPTION
As per @Boddlnagg's [comment](https://github.com/jonas-k/coremidi-sys/pull/7#issuecomment-628101092), this PR removes the derivation of `Copy` and `Clone` `MIDIPacket` and `MIDIPacketList`, since these structs cannot be copied or cloned safely.

Thanks so much!