### PR TITLE
Fix MIDIPacketNext failing to add proper offset to data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coremidi-sys"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Jonas Klesy", "Patrick Reisert"]
 description = "Low-level FFI bindings for the CoreMIDI framework"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ include!("generated.rs");
 pub unsafe fn MIDIPacketNext(pkt: *const MIDIPacket) -> *const MIDIPacket {
     // Get pointer to potentially unaligned data without triggering undefined behavior
     // addr_of does not require creating an intermediate reference to unaligned data.
-    let ptr = ptr::addr_of!((*pkt).data);
+    let ptr = ptr::addr_of!((*pkt).data) as *const u8;
     let offset = (*pkt).length as isize;
     if cfg!(any(target_arch = "arm", target_arch = "aarch64")) {
         // MIDIPacket must be 4-byte aligned on ARM


### PR DESCRIPTION
Fixes #13 

The version 3.0.0 should be marked as yanked, and a new release 3.0.1 will be necessary.