### PR TITLE
fix clippy::missing_transmute_annotations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,10 +54,10 @@ mod static_test {
         use std::mem::{transmute, zeroed};
 
         let p: MIDIPacket = zeroed();
-        transmute::<_, [u8; 268]>(p);
+        transmute::<MIDIPacket, [u8; 268]>(p);
 
         let p: MIDIPacketList = zeroed();
-        transmute::<_, [u8; 272]>(p);
+        transmute::<MIDIPacketList, [u8; 272]>(p);
     }
 }
 


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#missing_transmute_annotations